### PR TITLE
Restructure S3 file path

### DIFF
--- a/ckanext/datagovsg_s3_resources/upload.py
+++ b/ckanext/datagovsg_s3_resources/upload.py
@@ -73,15 +73,15 @@ def upload_resource_to_s3(context, resource):
     extension = mimetypes.guess_extension(content_type)
 
     # Upload to S3
+    timestamp = datetime.datetime.utcnow()
     pkg = toolkit.get_action('package_show')(context, {'id': resource['package_id']})
-    timestamp = datetime.datetime.utcnow() # should match the assignment in the ResourceUpload class
     s3_filepath = (pkg.get('name')
                    + '/'
                    + 'resources'
                    + '/'
-                   + slugify(resource.get('name'), to_lower=True)
+                   + resource.get('timestamp', timestamp.strftime("%Y-%m-%dT%H-%M-%SZ"))
                    + '-'
-                   + timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
+                   + slugify(resource.get('name'))
                    + extension)
 
     # If file is currently being uploaded, the file is in resource['upload']
@@ -153,7 +153,7 @@ def upload_resource_zipfile_to_s3(context, resource):
     # Init logger
     logger = logging.getLogger(__name__)
     logger.info("Starting upload_resource_zipfile_to_s3 for resource %s" % resource.get('name', ''))
-   
+
     # If resource is an API, skip upload
     if resource.get('format', '') == 'API':
         return


### PR DESCRIPTION
The s3 file path is currently constructed so that the timestamp
is added to the end of the file name. This is causing issues where
the file's organogram visualisation isn't showing, and is expecting
a file name that ends in `-senior.csv` or `-junior.csv`.

Moving the timestamp to the beginning of the file name should fix
this.

Paired with @kentsanggds 

Trello card: https://trello.com/c/5KrmZ1tb/1025-fix-bug-to-show-visualisation-on-junior-post-organograms